### PR TITLE
Fix/fe be heart icon handler duplicate favorite movies

### DIFF
--- a/packages/client/src/components/LatestRatingMovies/LatestRatingMovies.jsx
+++ b/packages/client/src/components/LatestRatingMovies/LatestRatingMovies.jsx
@@ -1,29 +1,30 @@
+import React, { useEffect, useState } from 'react';
+import styled from '@emotion/styled';
 import Masonry from '@mui/lab/Masonry';
 import { Box, Typography } from '@mui/material';
-import * as React from 'react';
-import { useEffect, useState } from 'react';
 import { apiURL } from '../../apiURL';
 import { MovieCard } from '../MovieCard/MovieCard';
-import styled from '@emotion/styled';
+import { useFavorites } from '../MovieCard/useFavorites';
 
 export const LatestRatingMovies = () => {
   const [movies, setMovies] = useState([]);
+  const [favorites, toggleFavorite] = useFavorites([]);
 
   useEffect(() => {
     async function fetchMovies() {
       try {
-        const response = await fetch(`${apiURL()}/movies`);
+        const response = await fetch(`${apiURL()}/reviews/rating/latest`);
         if (!response.ok) {
           throw new Error('Failed to fetch movies with the latest rating');
         }
         const data = await response.json();
-        setMovies(data.movies);
+        setMovies(data);
       } catch (error) {
-        return error;
+        throw new Error(error);
       }
     }
     fetchMovies();
-  }, []);
+  }, [favorites]);
 
   return (
     <StyledMovieGrid>
@@ -35,16 +36,22 @@ export const LatestRatingMovies = () => {
           width: '78rem',
         }}
       >
-        {movies
-          .map((movie) => <MovieCard key={movie.id} movie={movie} />)
-          .splice(2, 8)}
+        {movies.map(
+          (movie, index /* eslint-disable react/no-array-index-key */) => (
+            <MovieCard
+              key={`${movie.id}-${index}`}
+              movie={movie}
+              favorites={favorites}
+              toggleFavorite={toggleFavorite}
+            />
+          ),
+        )}
       </Masonry>
     </StyledMovieGrid>
   );
 };
 
 const StyledMovieGrid = styled(Box)`
-  height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/packages/client/src/components/MovieCard/MovieCard.jsx
+++ b/packages/client/src/components/MovieCard/MovieCard.jsx
@@ -32,12 +32,12 @@ export function MovieCard({ movie, favorites, toggleFavorite }) {
         alt={movie.title}
       />
       <StyledTypographyTitle>{movie.title}</StyledTypographyTitle>
-      <StyledTypographyDescription
+      <StyledTypographyReviewText
         paragraph
         sx={{ top: '2rem', fontWeight: 400 }}
       >
-        {movie.description}
-      </StyledTypographyDescription>
+        {movie.review_text}
+      </StyledTypographyReviewText>
       <BasicRating />
     </StyledCard>
   );
@@ -123,7 +123,7 @@ const StyledTypographyTitle = styled(Typography)`
   font-weight: 700;
 `;
 
-const StyledTypographyDescription = styled(Typography)`
+const StyledTypographyReviewText = styled(Typography)`
   ${sharedTypographyStyles}
   top: 2rem;
   font-weight: 400;

--- a/packages/client/src/components/MovieCard/MovieCard.jsx
+++ b/packages/client/src/components/MovieCard/MovieCard.jsx
@@ -4,8 +4,8 @@ import styled from '@emotion/styled';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
-const BasicRating = () => {
-  return <StyledRating name="read-only" value={4} readOnly />;
+const BasicRating = ({ rating }) => {
+  return <StyledRating name="read-only" value={rating} readOnly />;
 };
 
 export function MovieCard({ movie, favorites, toggleFavorite }) {
@@ -38,7 +38,7 @@ export function MovieCard({ movie, favorites, toggleFavorite }) {
       >
         {movie.review_text}
       </StyledTypographyReviewText>
-      <BasicRating />
+      <BasicRating rating={movie.rating} />
     </StyledCard>
   );
 }

--- a/packages/client/src/components/MovieCard/MovieCard.jsx
+++ b/packages/client/src/components/MovieCard/MovieCard.jsx
@@ -3,29 +3,27 @@ import { Card, CardMedia, Typography, Rating, Box } from '@mui/material';
 import styled from '@emotion/styled';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
-import { useFavorites } from './useFavorites'; // created a custom hook to manage favorites
 
 const BasicRating = () => {
   return <StyledRating name="read-only" value={4} readOnly />;
 };
 
-export function MovieCard({ movie }) {
-  const [favorites, toggleFavorite] = useFavorites([]);
+export function MovieCard({ movie, favorites, toggleFavorite }) {
   const isFavorite = favorites.find(
     (favoriteMovie) => favoriteMovie.id === movie.id,
   );
 
   return (
     <StyledCard>
-      <Box
-        sx={{
-          position: 'relative',
-        }}
-      >
+      <Box sx={{ position: 'relative' }}>
         {isFavorite ? (
-          <StyledFavoriteIcon onClick={() => toggleFavorite(movie)} />
+          <StyledFavoriteIcon
+            onClick={() => toggleFavorite(movie, isFavorite)}
+          />
         ) : (
-          <StyledFavoriteBorderIcon onClick={() => toggleFavorite(movie)} />
+          <StyledFavoriteBorderIcon
+            onClick={() => toggleFavorite(movie, isFavorite)}
+          />
         )}
       </Box>
       <StyledCardMedia
@@ -34,7 +32,6 @@ export function MovieCard({ movie }) {
         alt={movie.title}
       />
       <StyledTypographyTitle>{movie.title}</StyledTypographyTitle>
-
       <StyledTypographyDescription
         paragraph
         sx={{ top: '2rem', fontWeight: 400 }}
@@ -73,20 +70,20 @@ const StyledCard = styled(Card)`
 `;
 
 const sharedIconStyles = `
-    display: block;
-    position: absolute;
-    width: 2rem;
-    height: 1.75rem;
-    top: 2.25rem;
-    right: 2rem;
-    color: #FFFFFF;
-    padding: .75rem;
-    background-color: #000000cc;
-    z-index: 1;
-    &:hover {
-      color: #ff0000;
-      cursor: pointer;
-    }
+  display: block;
+  position: absolute;
+  width: 2rem;
+  height: 1.75rem;
+  top: 2.25rem;
+  right: 2rem;
+  color: #FFFFFF;
+  padding: .75rem;
+  background-color: #000000cc;
+  z-index: 1;
+  &:hover {
+    color: #ff0000;
+    cursor: pointer;
+  }
 `;
 
 const StyledFavoriteIcon = styled(FavoriteIcon)`

--- a/packages/client/src/components/MovieCard/useFavorites.js
+++ b/packages/client/src/components/MovieCard/useFavorites.js
@@ -17,19 +17,19 @@ export const useFavorites = (initialFavorites = []) => {
         const data = await response.json();
         setFavorites(data);
       } catch (error) {
-        return error;
+        throw new Error(error);
       }
     };
+
     getFavoriteMovies();
+
     return () => {
       abortController.abort();
     };
   }, []);
 
-  const toggleFavorite = (item) => {
-    const foundMovie = favorites.find((movie) => movie.id === item.id);
-
-    if (foundMovie) {
+  const toggleFavorite = (item, isFavorites) => {
+    if (isFavorites) {
       handleRemoveFavorite(item.id, item, favorites, setFavorites, userId);
     } else {
       handleAddFavorite(item.id, item, favorites, setFavorites, userId);

--- a/packages/server/api/controllers/reviews.controller.js
+++ b/packages/server/api/controllers/reviews.controller.js
@@ -4,6 +4,7 @@ const HttpError = require('../lib/utils/http-error');
 const getLatestRatedMovies = async () => {
   return knex('reviews')
     .select(
+      'movies.id',
       'movies.image_location',
       'movies.backdrop_URL',
       'movies.title',


### PR DESCRIPTION
# Description

**BE**

Add movie.id in getLatestRatedMovies

**FE**

- Changed LatestRatedMovie fetching endpoint from movies to reviews/rating/latest
- Lift favorite state from MovieCard to LatestRatedMovie to be able to update heart icon styled(filled heart) 
_In the previous code, if there are duplicate movies rendered with the rating component, clicking on the heart icon will only update the styles for the specific element that was clicked._

- Removed height in styled rating according to design in Figma

- Replace movie description to movie review_text  

- Replace hard-coding value start rate value to dynamically value 

# Jira task link
https://hackyourfuture-dk.atlassian.net/jira/software/projects/LANDING/boards/6?selectedIssue=LANDING-61
https://hackyourfuture-dk.atlassian.net/jira/software/projects/LANDING/boards/6?selectedIssue=LANDING-71

# Screenshots (if applicable)



https://github.com/HackYourFuture-CPH/CINEMANIA/assets/94117213/b4b26552-976c-49f9-8c28-ec4a1548d4e3

